### PR TITLE
feat : added proof storage and api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,40 +1,40 @@
 [workspace]
 resolver = "2"
 members = [
-    "relayer",
-    "core",
-    "nexus/host",
-    "nexus/prover",
-    "nexus/prover/sp1-guest",
-    "nexus/prover/risc0-guest",
-    "examples/demo_rollup/host",
-    "examples/demo_rollup/methods",
-    "examples/demo_rollup/methods/guest",
-    "examples/demo_rollup/core",
-    "examples/mock_geth_adapter/host",
-    "examples/mock_geth_adapter/methods",
-    "examples/mock_geth_adapter/methods/guest",
-    "examples/mock_geth_adapter/core",
-    "examples/zksync_adapter/host",
-    "examples/zksync_adapter/methods",
-    "examples/zksync_adapter/methods/risc0-guest",
-    "examples/zksync_adapter/methods/sp1-guest",
-    "examples/zksync_adapter/core",
-    "examples/ethereum_adapter/methods",
-    "examples/ethereum_adapter/host",
-    "adapter_sdk",
-    "nexus_cli",
-    "examples/zksync_adapter/bench",
-    "nexus/bench",
-    "nexus_bench_setup",
-    "kzg",
-    "mock_elf",
-    "mock_elf/risc0-guest",
-    "mock_elf/sp1-guest",
-    "examples/ethereum_adapter/core",
-    "examples/ethereum_adapter/methods/risc0-guest",
-    "examples/ethereum_adapter/methods/sp1-guest",
-    "integration",
+  "relayer",
+  "core",
+  "nexus/host",
+  "nexus/prover",
+  "nexus/prover/sp1-guest",
+  "nexus/prover/risc0-guest",
+  "examples/demo_rollup/host",
+  "examples/demo_rollup/methods",
+  "examples/demo_rollup/methods/guest",
+  "examples/demo_rollup/core",
+  "examples/mock_geth_adapter/host",
+  "examples/mock_geth_adapter/methods",
+  "examples/mock_geth_adapter/methods/guest",
+  "examples/mock_geth_adapter/core",
+  "examples/zksync_adapter/host",
+  "examples/zksync_adapter/methods",
+  "examples/zksync_adapter/methods/risc0-guest",
+  "examples/zksync_adapter/methods/sp1-guest",
+  "examples/zksync_adapter/core",
+  "examples/ethereum_adapter/methods",
+  "examples/ethereum_adapter/host",
+  "adapter_sdk",
+  "nexus_cli",
+  "examples/zksync_adapter/bench",
+  "nexus/bench",
+  "nexus_bench_setup",
+  "kzg",
+  "mock_elf",
+  "mock_elf/risc0-guest",
+  "mock_elf/sp1-guest",
+  "examples/ethereum_adapter/core",
+  "examples/ethereum_adapter/methods/risc0-guest",
+  "examples/ethereum_adapter/methods/sp1-guest",
+  "integration",
 ]
 
 [workspace.package]
@@ -43,27 +43,27 @@ version = "1.0.0"
 [workspace.dependencies]
 #Helios dependencies
 helios-consensus-core = { git = "https://github.com/a16z/helios", tag = "0.8.1" }
-helios-ethereum       = { git = "https://github.com/a16z/helios", tag = "0.8.1" }
-tree_hash             = "0.9.0"
-alloy                 = { version = "0.9.1", features = [ "full" ] }
-alloy-sol-types       = "0.8.15"
+helios-ethereum = { git = "https://github.com/a16z/helios", tag = "0.8.1" }
+tree_hash = "0.9.0"
+alloy = { version = "0.9.1", features = ["full"] }
+alloy-sol-types = "0.8.15"
 
 #General dependencies
 serde = "1.0"
 anyhow = "1.0"
 serde_json = "1.0.113"
-reqwest = { version = "0.12.9", features = [ "json" ] }
+reqwest = { version = "0.12.9", features = ["json"] }
 tokio = "1.38.0"
 derive_more = { git = "https://github.com/JelteF/derive_more", tag = "v1.0.0", features = [
-    "display",
+  "display",
 ] }
 tracing = "0.1.41"
 
 [patch.crates-io]
-sp-core         = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
-sp-io           = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
-sp-runtime      = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
-sp-std          = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
+sp-core = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
+sp-io = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
+sp-runtime = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
+sp-std = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
 sp-core-hashing = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
 # Remove below patch once rust version can be updated for zkvm
 bumpalo = { git = "https://github.com/fitzgen/bumpalo", tag = "3.14.0" }

--- a/adapter_sdk/Cargo.toml
+++ b/adapter_sdk/Cargo.toml
@@ -1,35 +1,35 @@
 [package]
-name              = "adapter_sdk"
+name = "adapter_sdk"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio        = { version = "1.36.0", optional = true }
-hex          = { version = "0.4", optional = true }
+tokio = { version = "1.36.0", optional = true }
+hex = { version = "0.4", optional = true }
 tokio-stream = { version = "0.1.14", optional = true }
-reqwest      = { version = "0.11.24", features = [ "json" ], optional = true }
-nexus-core   = { path = "../core", default-features = false, optional = true }
-serde        = "1.0.203"
-serde_json   = "1.0.113"
-anyhow       = "1.0.81"
-warp         = { version = "0.3", optional = true }
-risc0-zkvm   = { version = "2.0.0", default-features = false, optional = true }
-relayer      = { path = "../relayer", optional = true }
-sp1-sdk      = { version = "4.1.0", optional = true }
-sp1-zkvm     = { version = "4.1.0", optional = true }
-digest       = { version = "0.10.0" }
+reqwest = { version = "0.11.24", features = ["json"], optional = true }
+nexus-core = { path = "../core", default-features = false, optional = true }
+serde = "1.0.203"
+serde_json = "1.0.113"
+anyhow = "1.0.81"
+warp = { version = "0.3", optional = true }
+risc0-zkvm = { version = "2.0.0", default-features = false, optional = true }
+relayer = { path = "../relayer", optional = true }
+sp1-sdk = { version = "4.1.0", optional = true }
+sp1-zkvm = { version = "4.1.0", optional = true }
+digest = { version = "0.10.0" }
 
 [features]
-default = [ "native-risc0" ]
-native = [ "relayer", "reqwest", "hex", "tokio", "tokio-stream", "warp" ]
-zkvm-sp1 = [ "nexus-core/zkvm-sp1", "sp1-zkvm" ]
-zkvm-risc0 = [ "nexus-core/zkvm-risc0", "risc0-zkvm/std" ]
-native-risc0 = [ "risc0-zkvm/default", "nexus-core/native-risc0", "native" ]
-native-sp1 = [ "sp1-sdk", "nexus-core/native-sp1", "native" ]
+default = ["native-risc0"]
+native = ["relayer", "reqwest", "hex", "tokio", "tokio-stream", "warp"]
+zkvm-sp1 = ["nexus-core/zkvm-sp1", "sp1-zkvm"]
+zkvm-risc0 = ["nexus-core/zkvm-risc0", "risc0-zkvm/std"]
+native-risc0 = ["risc0-zkvm/default", "nexus-core/native-risc0", "native"]
+native-sp1 = ["sp1-sdk", "nexus-core/native-sp1", "native"]
 native-risc0-cuda = [
-    "risc0-zkvm/cuda",
-    "nexus-core/native-risc0-cuda",
-    "native",
+  "risc0-zkvm/cuda",
+  "nexus-core/native-risc0-cuda",
+  "native",
 ]

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,16 +1,16 @@
 [profile.default]
-src            = "src"
-out            = "out"
-libs           = [ "lib" ]
-solc_version   = "0.8.21"
-fs_permissions = [ { access = "read", path = "./" } ]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.21"
+fs_permissions = [{ access = "read", path = "./" }]
 
 
 [profile.solc]
 version = "0.8.21"
 
 [rpc_endpoints]
-sepolia     = "${SEPOLIA_RPC_URL}"
+sepolia = "${SEPOLIA_RPC_URL}"
 zksync_era1 = "${ZKSYNC_ERA1_RPC_URL}"
 zksync_era2 = "${ZKSYNC_ERA2_RPC_URL}"
 

--- a/core/.sqlx/query-9542d305c78fcc1136bed80704064fdcdf9608adba96ba76f6265bae32957d3f.json
+++ b/core/.sqlx/query-9542d305c78fcc1136bed80704064fdcdf9608adba96ba76f6265bae32957d3f.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO proofs (block_hash, block_number, proof)\n            VALUES ($1, $2, $3)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Int8",
+        "Bytea"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9542d305c78fcc1136bed80704064fdcdf9608adba96ba76f6265bae32957d3f"
+}

--- a/core/.sqlx/query-eae2b4eeee8b31d3dbbf48fc229ffb3ac5106e83507950663516fc555ae931e8.json
+++ b/core/.sqlx/query-eae2b4eeee8b31d3dbbf48fc229ffb3ac5106e83507950663516fc555ae931e8.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * FROM proofs\n            WHERE block_number = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "block_hash",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 1,
+        "name": "block_number",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "proof",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "eae2b4eeee8b31d3dbbf48fc229ffb3ac5106e83507950663516fc555ae931e8"
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,47 +1,45 @@
 [package]
-name              = "nexus-core"
+name = "nexus-core"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0.79"
 avail-subxt = { git = "https://github.com/availproject/avail.git", tag = "v1.11.0.0", features = [
-    "std",
+  "std",
 ], optional = true }
 avail-core = { git = "https://github.com/availproject/avail-core", rev = "d62ce4875148a69a62d77f224ed6dbe060cc92f5", default-features = false, features = [
-    "serde",
-    "runtime",
+  "serde",
+  "runtime",
 ], optional = true }
 serde = "1.0.196"
 sparse-merkle-tree = { git = "https://github.com/vibhurajeev/sparse-merkle-tree.git", rev = "a2f94a7", optional = true, default-features = false }
 rocksdb = { version = "0.22.0", optional = true }
 sqlx = { version = "0.7", features = [
-    "postgres",
-    "runtime-tokio",
-    "macros",
-    "migrate",
+  "postgres",
+  "runtime-tokio",
+  "macros",
+  "migrate",
 ], optional = true }
 serde_json = "1.0.114"
 parity-scale-codec = { version = "3", default-features = false, features = [
-    "derive",
-    "max-encoded-len",
+  "derive",
+  "max-encoded-len",
 ] }
-scale-info = { version = "2", default-features = false, features = [
-    "derive",
-] }
+scale-info = { version = "2", default-features = false, features = ["derive"] }
 blake2b_simd = "1.0.2"
 serde-big-array = "0.5.1"
 tokio = { version = "1.36.0", optional = true }
 bincode = "1.3.3"
 solabi = "0.2.0"
-jmt = { git = "https://github.com/vibhurajeev/jmt.git", features = [ "mocks" ] }
+jmt = { git = "https://github.com/vibhurajeev/jmt.git", features = ["mocks"] }
 ethabi = "18.0.0"
 sp1-sdk = { version = "3.4.0", optional = true }
 sp1-zkvm = { version = "3.4.0", optional = true }
 risc0-zkvm = { version = "2.0.0", default-features = false, features = [
-    "std",
+  "std",
 ], optional = true }
 sha2 = { version = "0.10.8" }
 hex = "0.4.3"
@@ -54,20 +52,20 @@ avail-rust = { git = "https://github.com/availproject/avail-rust.git", branch = 
 
 [features]
 native = [
-    "rocksdb",
-    "sqlx",
-    "sparse-merkle-tree/arch-64",
-    "sparse-merkle-tree/std",
-    "avail-subxt",
-    "avail-core",
-    "tokio",
-    "dep:tracing",
-    "utoipa",
-    "avail-rust",
+  "rocksdb",
+  "sqlx",
+  "sparse-merkle-tree/arch-64",
+  "sparse-merkle-tree/std",
+  "avail-subxt",
+  "avail-core",
+  "tokio",
+  "dep:tracing",
+  "utoipa",
+  "avail-rust",
 ]
-zkvm = [ "sparse-merkle-tree/arch-32", "sparse-merkle-tree/std" ]
-native-sp1 = [ "sp1-sdk", "sp1-zkvm/verify", "native", "mock_elf/sp1" ]
-native-risc0 = [ "risc0-zkvm/prove", "native", "mock_elf/risc0" ]
-zkvm-sp1 = [ "sp1-zkvm/verify", "zkvm" ]
-zkvm-risc0 = [ "risc0-zkvm/std", "zkvm" ]
-native-risc0-cuda = [ "risc0-zkvm/cuda", "native", "mock_elf/risc0" ]
+zkvm = ["sparse-merkle-tree/arch-32", "sparse-merkle-tree/std"]
+native-sp1 = ["sp1-sdk", "sp1-zkvm/verify", "native", "mock_elf/sp1"]
+native-risc0 = ["risc0-zkvm/prove", "native", "mock_elf/risc0"]
+zkvm-sp1 = ["sp1-zkvm/verify", "zkvm"]
+zkvm-risc0 = ["risc0-zkvm/std", "zkvm"]
+native-risc0-cuda = ["risc0-zkvm/cuda", "native", "mock_elf/risc0"]

--- a/core/migrations/20250422130724_create_nexus_table.sql
+++ b/core/migrations/20250422130724_create_nexus_table.sql
@@ -15,3 +15,9 @@ CREATE TABLE transaction_with_status (
     status TEXT NOT NULL,
     block_hash BYTEA
 );
+
+CREATE TABLE proofs (
+    block_hash BYTEA PRIMARY KEY,
+    block_number BIGINT NOT NULL,
+    proof BYTEA NOT NULL
+);

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::traits::NexusTransaction;
+use crate::types::BlockProof;
 use crate::types::BlockStatus;
 use crate::types::NexusBlockWithPointers;
 use crate::types::NexusBlockWithPointersDbResponse;
@@ -262,5 +263,34 @@ impl SharedDB {
         .execute(&self.db)
         .await?;
         Ok(())
+    }
+
+    pub async fn insert_proof(&self, block_number: u64, block_hash: H256, proof: Vec<u8>) -> anyhow::Result<()> {
+        sqlx::query!(
+            r#"
+            INSERT INTO proofs (block_hash, block_number, proof)
+            VALUES ($1, $2, $3)
+            "#,
+            block_hash.as_slice(),
+            block_number as i64,
+            proof.as_slice()
+        )
+        .execute(&self.db)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn get_block_proof_by_number(&self, block_number: u64) -> anyhow::Result<Option<BlockProof>> {
+        let block_proof = sqlx::query_as!(
+            BlockProof,
+            r#"
+            SELECT * FROM proofs
+            WHERE block_number = $1
+            "#,
+            block_number as i64
+        )
+        .fetch_optional(&self.db)
+        .await?;
+        Ok(block_proof)
     }
 }

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -246,6 +246,14 @@ pub struct NexusBlockWithPointersDbResponse {
     pub block_status: String,
 }
 
+#[cfg(any(feature = "native"))]
+#[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
+pub struct BlockProof {
+    pub block_hash: Vec<u8>,
+    pub block_number: i64,
+    pub proof: Vec<u8>,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StateUpdate {
     pub pre_state_root: H256,

--- a/examples/demo_rollup/core/Cargo.toml
+++ b/examples/demo_rollup/core/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name              = "demo_rollup_core"
+name = "demo_rollup_core"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 adapter_sdk = { path = "../../../adapter_sdk", default-features = false, features = [
-    "zkvm-risc0",
+  "zkvm-risc0",
 ] }
 anyhow = "1.0.81"
 nexus-core = { path = "../../../core", default-features = false, features = [
-    "zkvm-risc0",
+  "zkvm-risc0",
 ] }
 serde = "1.0.197"

--- a/examples/demo_rollup/host/Cargo.toml
+++ b/examples/demo_rollup/host/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name              = "adapter-host"
+name = "adapter-host"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 methods = { path = "../methods" }
 risc0-zkvm = { version = "2.0.0" }
-tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = "1.0"
-nexus-core = { path = "../../../core", features = [ "native-risc0" ] }
+nexus-core = { path = "../../../core", features = ["native-risc0"] }
 serde_json = "1.0.114"
 tokio = "1.36.0"
 sp-runtime = "33.0.0"
 parity-scale-codec = { version = "3", default-features = false, features = [
-    "derive",
-    "max-encoded-len",
+  "derive",
+  "max-encoded-len",
 ] }
 relayer = { path = "../../../relayer" }
-adapter_sdk = { path = "../../../adapter_sdk", features = [ "native-risc0" ] }
+adapter_sdk = { path = "../../../adapter_sdk", features = ["native-risc0"] }
 demo_rollup_core = { path = "../core" }
 anyhow = "1.0.80"
 actix-web = "4.5.1"

--- a/examples/demo_rollup/methods/Cargo.toml
+++ b/examples/demo_rollup/methods/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name              = "methods"
+name = "methods"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [build-dependencies]
 risc0-build = { version = "2.0.0" }
 
 [package.metadata.risc0]
-methods = [ "guest" ]
+methods = ["guest"]

--- a/examples/demo_rollup/methods/guest/Cargo.toml
+++ b/examples/demo_rollup/methods/guest/Cargo.toml
@@ -1,17 +1,15 @@
 [package]
-name              = "demo-rollup-adapter"
+name = "demo-rollup-adapter"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 # If you want to try (experimental) std support, add `features = [ "std" ]` to risc0-zkvm
-risc0-zkvm = { version = "2.0.0", default-features = false, features = [
-    "std",
-] }
+risc0-zkvm = { version = "2.0.0", default-features = false, features = ["std"] }
 nexus-core = { path = "../../../../core", default-features = false, features = [
-    "zkvm",
+  "zkvm",
 ] }
 adapter_sdk = { path = "../../../../adapter_sdk", default-features = false, features = [
-    "zkvm-risc0",
+  "zkvm-risc0",
 ] }
 demo_rollup_core = { path = "../../core" }

--- a/examples/ethereum_adapter/core/Cargo.toml
+++ b/examples/ethereum_adapter/core/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name              = "ethereum-core"
-edition           = "2021"
+name = "ethereum-core"
+edition = "2021"
 version.workspace = true
 
 [dependencies]
-adapter_sdk           = { path = "../../../adapter_sdk", default-features = false, optional = true }
-nexus-core            = { path = "../../../core", default-features = false, optional = true }
-anyhow                = { workspace = true }
+adapter_sdk = { path = "../../../adapter_sdk", default-features = false, optional = true }
+nexus-core = { path = "../../../core", default-features = false, optional = true }
+anyhow = { workspace = true }
 helios-consensus-core = { workspace = true }
-tree_hash             = { workspace = true }
-alloy-primitives      = "0.8.15"
-serde_cbor            = "0.11.2"
-serde                 = { workspace = true, features = [ "derive" ] }
-tracing               = { workspace = true }
+tree_hash = { workspace = true }
+alloy-primitives = "0.8.15"
+serde_cbor = "0.11.2"
+serde = { workspace = true, features = ["derive"] }
+tracing = { workspace = true }
 
 [features]
-default    = [ "risc0" ]
-zkvm-risc0 = [ "nexus-core/zkvm-risc0", "adapter_sdk/zkvm-risc0" ]
-zkvm-sp1   = [ "nexus-core/zkvm-sp1", "adapter_sdk/zkvm-sp1" ]
-risc0      = [ "nexus-core/native-risc0", "adapter_sdk/native-risc0", "native" ]
-sp1        = [ "nexus-core/native-sp1", "adapter_sdk/native-sp1", "native" ]
-native     = [ "nexus-core/native" ]
+default = ["risc0"]
+zkvm-risc0 = ["nexus-core/zkvm-risc0", "adapter_sdk/zkvm-risc0"]
+zkvm-sp1 = ["nexus-core/zkvm-sp1", "adapter_sdk/zkvm-sp1"]
+risc0 = ["nexus-core/native-risc0", "adapter_sdk/native-risc0", "native"]
+sp1 = ["nexus-core/native-sp1", "adapter_sdk/native-sp1", "native"]
+native = ["nexus-core/native"]

--- a/examples/ethereum_adapter/host/Cargo.toml
+++ b/examples/ethereum_adapter/host/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name    = "ethereum-adapter-host"
+name = "ethereum-adapter-host"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,7 +7,7 @@ edition = "2021"
 ethereum-adapter-methods = { path = "../methods", default-features = false }
 risc0-zkvm = { version = "2.0.0", default-features = false, optional = true }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dotenv = "0.15.0"
 clap = "4.5.9"
 env_logger = "0.11.3"
@@ -28,29 +28,29 @@ adapter_sdk = { path = "../../../adapter_sdk", default-features = false }
 ethereum-core = { path = "../core", default-features = false }
 sp1-sdk = { version = "4.1.0", optional = true }
 derive_more = { git = "https://github.com/JelteF/derive_more", tag = "v1.0.0", features = [
-    "display",
+  "display",
 ] }
 
 [features]
-default = [ "risc0" ]
+default = ["risc0"]
 sp1 = [
-    "sp1-sdk",
-    "nexus-core/native-sp1",
-    "ethereum-adapter-methods/sp1",
-    "ethereum-core/sp1",
-    "adapter_sdk/zkvm-sp1",
+  "sp1-sdk",
+  "nexus-core/native-sp1",
+  "ethereum-adapter-methods/sp1",
+  "ethereum-core/sp1",
+  "adapter_sdk/zkvm-sp1",
 ]
 risc0 = [
-    "risc0-zkvm/std",
-    "nexus-core/native-risc0",
-    "ethereum-adapter-methods/risc0",
-    "ethereum-core/risc0",
-    "adapter_sdk/zkvm-risc0",
+  "risc0-zkvm/std",
+  "nexus-core/native-risc0",
+  "ethereum-adapter-methods/risc0",
+  "ethereum-core/risc0",
+  "adapter_sdk/zkvm-risc0",
 ]
 risc0-cuda = [
-    "risc0-zkvm/cuda",
-    "nexus-core/native-risc0-cuda",
-    "ethereum-adapter-methods/risc0",
-    "ethereum-core/zkvm-risc0",
-    "adapter_sdk/zkvm-risc0",
+  "risc0-zkvm/cuda",
+  "nexus-core/native-risc0-cuda",
+  "ethereum-adapter-methods/risc0",
+  "ethereum-core/zkvm-risc0",
+  "adapter_sdk/zkvm-risc0",
 ]

--- a/examples/ethereum_adapter/methods/Cargo.toml
+++ b/examples/ethereum_adapter/methods/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name              = "ethereum-adapter-methods"
+name = "ethereum-adapter-methods"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [build-dependencies]
 risc0-build = { version = "2.0.0", optional = true }
-sp1-build   = { version = "4.1.0", optional = true }
+sp1-build = { version = "4.1.0", optional = true }
 
 [package.metadata.risc0]
-methods = [ "risc0-guest" ]
+methods = ["risc0-guest"]
 
 [features]
-sp1   = [ "sp1-build" ]
-risc0 = [ "risc0-build" ]
+sp1 = ["sp1-build"]
+risc0 = ["risc0-build"]

--- a/examples/ethereum_adapter/methods/risc0-guest/Cargo.toml
+++ b/examples/ethereum_adapter/methods/risc0-guest/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
-name              = "ethereum-adapter"
+name = "ethereum-adapter"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
-risc0-zkvm = { version = "2.0.0", default-features = false, features = [
-    'std',
-] }
+risc0-zkvm = { version = "2.0.0", default-features = false, features = ['std'] }
 nexus-core = { path = "../../../../core", default-features = false, features = [
-    "zkvm-risc0",
+  "zkvm-risc0",
 ] }
 ethereum-core = { path = "../../core", default-features = false, features = [
-    "zkvm-risc0",
+  "zkvm-risc0",
 ] }

--- a/examples/ethereum_adapter/methods/sp1-guest/Cargo.toml
+++ b/examples/ethereum_adapter/methods/sp1-guest/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name              = "ethereum-adapter-sp1"
+name = "ethereum-adapter-sp1"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 nexus-core = { path = "../../../../core", default-features = false, features = [
-    "zkvm-sp1",
+  "zkvm-sp1",
 ] }
 ethereum-core = { path = "../../core", default-features = false, features = [
-    "zkvm-sp1",
+  "zkvm-sp1",
 ] }
-sp1-zkvm = { version = "4.1.0", features = [ "verify" ] }
+sp1-zkvm = { version = "4.1.0", features = ["verify"] }
 sp1-derive = { version = "4.1.0" }

--- a/examples/mock_geth_adapter/core/Cargo.toml
+++ b/examples/mock_geth_adapter/core/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name              = "geth-adapter-core"
+name = "geth-adapter-core"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 adapter_sdk = { path = "../../../adapter_sdk", default-features = false, features = [
-    "zkvm-risc0",
+  "zkvm-risc0",
 ] }
 anyhow = "1.0.81"
 nexus-core = { path = "../../../core", default-features = false, features = [
-    "zkvm-risc0",
+  "zkvm-risc0",
 ] }
 serde = "1.0.197"

--- a/examples/mock_geth_adapter/host/Cargo.toml
+++ b/examples/mock_geth_adapter/host/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name              = "geth-adapter-host"
+name = "geth-adapter-host"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 geth-methods = { path = "../methods" }
-risc0-zkvm = { version = "2.0.0", features = [ "default" ] }
-tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
+risc0-zkvm = { version = "2.0.0", features = ["default"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = "1.0"
-nexus-core = { path = "../../../core", features = [ "native-risc0" ] }
+nexus-core = { path = "../../../core", features = ["native-risc0"] }
 serde_json = "1.0.114"
 tokio = "1.36.0"
 sp-runtime = "33.0.0"
 parity-scale-codec = { version = "3", default-features = false, features = [
-    "derive",
-    "max-encoded-len",
+  "derive",
+  "max-encoded-len",
 ] }
 relayer = { path = "../../../relayer" }
-adapter_sdk = { path = "../../../adapter_sdk", features = [ "native-risc0" ] }
+adapter_sdk = { path = "../../../adapter_sdk", features = ["native-risc0"] }
 geth-adapter-core = { path = "../core" }
 anyhow = "1.0.80"
 actix-web = "4.5.1"

--- a/examples/mock_geth_adapter/methods/Cargo.toml
+++ b/examples/mock_geth_adapter/methods/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name              = "geth-methods"
+name = "geth-methods"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [build-dependencies]
 risc0-build = { version = "2.0.0" }
 
 [package.metadata.risc0]
-methods = [ "guest" ]
+methods = ["guest"]

--- a/examples/mock_geth_adapter/methods/guest/Cargo.toml
+++ b/examples/mock_geth_adapter/methods/guest/Cargo.toml
@@ -1,17 +1,15 @@
 [package]
-name              = "adapter"
+name = "adapter"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 # If you want to try (experimental) std support, add `features = [ "std" ]` to risc0-zkvm
-risc0-zkvm = { version = "2.0.0", default-features = false, features = [
-    "std",
-] }
+risc0-zkvm = { version = "2.0.0", default-features = false, features = ["std"] }
 nexus-core = { path = "../../../../core", default-features = false, features = [
-    "zkvm-risc0",
+  "zkvm-risc0",
 ] }
 adapter_sdk = { path = "../../../../adapter_sdk", default-features = false, features = [
-    "zkvm-risc0",
+  "zkvm-risc0",
 ] }
 geth-adapter-core = { path = "../../core" }

--- a/examples/zksync_adapter/bench/Cargo.toml
+++ b/examples/zksync_adapter/bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name              = "bench"
+name = "bench"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 nexus-core = { path = "../../../core", default-features = false, optional = true }
@@ -11,7 +11,7 @@ primitive-types = "0.12"
 zksync_basic_types = { git = "https://github.com/vibhurajeev/zksync-era" }
 zksync-methods = { path = "../methods", default-features = false, optional = true }
 risc0-zkvm = { version = "2.0.0", default-features = false, features = [
-    "std",
+  "std",
 ], optional = true }
 sp1-sdk = { version = "4.1.0", optional = true }
 bincode = "1.3.3"
@@ -19,21 +19,21 @@ env_logger = "0.11.5"
 log = "0.4.22"
 
 [[bench]]
-name    = "adapter_bench"
-path    = "src/adapter_bench.rs"
-harness = false                  #disable default harness
+name = "adapter_bench"
+path = "src/adapter_bench.rs"
+harness = false               #disable default harness
 
 [features]
-default = [ "risc0" ]
+default = ["risc0"]
 risc0 = [
-    "nexus-core/native-risc0",
-    "zksync-core/risc0",
-    "zksync-methods/risc0",
-    "risc0-zkvm/cuda",
+  "nexus-core/native-risc0",
+  "zksync-core/risc0",
+  "zksync-methods/risc0",
+  "risc0-zkvm/cuda",
 ]
 sp1 = [
-    "nexus-core/native-sp1",
-    "zksync-core/sp1",
-    "zksync-methods/sp1",
-    "sp1-sdk/cuda",
+  "nexus-core/native-sp1",
+  "zksync-core/sp1",
+  "zksync-methods/sp1",
+  "sp1-sdk/cuda",
 ]

--- a/examples/zksync_adapter/core/Cargo.toml
+++ b/examples/zksync_adapter/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name              = "zksync-core"
+name = "zksync-core"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,18 +15,18 @@ zksync_types = { git = "https://github.com/vibhurajeev/zksync-era", optional = t
 hex = "0.4.3"
 ethers-core = "2.0.14"
 num-bigint = "0.4.4"
-tiny-keccak = { version = "2.0", features = [ "sha3", "keccak" ] }
+tiny-keccak = { version = "2.0", features = ["sha3", "keccak"] }
 bincode = { version = "1.3.3" }
 parity-scale-codec = { version = "3", default-features = false, features = [
-    "derive",
-    "max-encoded-len",
+  "derive",
+  "max-encoded-len",
 ] }
 substrate-bn = "0.6.0"
 
 [features]
-default    = [ "risc0" ]
-zkvm-risc0 = [ "nexus-core/zkvm-risc0", "adapter_sdk/zkvm-risc0" ]
-zkvm-sp1   = [ "nexus-core/zkvm-sp1", "adapter_sdk/zkvm-sp1" ]
-risc0      = [ "nexus-core/native-risc0", "adapter_sdk/native-risc0", "native" ]
-sp1        = [ "nexus-core/native-sp1", "adapter_sdk/native-sp1", "native" ]
-native     = [ "nexus-core/native", "zksync_types" ]
+default = ["risc0"]
+zkvm-risc0 = ["nexus-core/zkvm-risc0", "adapter_sdk/zkvm-risc0"]
+zkvm-sp1 = ["nexus-core/zkvm-sp1", "adapter_sdk/zkvm-sp1"]
+risc0 = ["nexus-core/native-risc0", "adapter_sdk/native-risc0", "native"]
+sp1 = ["nexus-core/native-sp1", "adapter_sdk/native-sp1", "native"]
+native = ["nexus-core/native", "zksync_types"]

--- a/examples/zksync_adapter/host/Cargo.toml
+++ b/examples/zksync_adapter/host/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name              = "zksync-adapter-host"
+name = "zksync-adapter-host"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 zksync-methods = { path = "../methods", default-features = false }
 risc0-zkvm = { version = "2.0.0", default-features = false }
-tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = "1.0"
 nexus-core = { path = "../../../core", default-features = false, optional = true }
 serde_json = "1.0.114"
 tokio = "1.36.0"
 sp-runtime = "33.0.0"
 parity-scale-codec = { version = "3", default-features = false, features = [
-    "derive",
-    "max-encoded-len",
+  "derive",
+  "max-encoded-len",
 ] }
 relayer = { path = "../../../relayer" }
 adapter_sdk = { path = "../../../adapter_sdk", default-features = false }
@@ -23,7 +23,7 @@ anyhow = "1.0.80"
 actix-web = "4.5.1"
 warp = "0.3.6"
 web3 = "0.19.0"
-reqwest = { version = "0.12.5", features = [ "json" ] }
+reqwest = { version = "0.12.5", features = ["json"] }
 sp1-sdk = { version = "4.1.0", optional = true }
 num-bigint = "0.4"
 primitive-types = "0.12"
@@ -32,18 +32,18 @@ log = "0.4.22"
 zksync_basic_types = { git = "https://github.com/vibhurajeev/zksync-era" }
 
 [features]
-default = [ "risc0" ]
+default = ["risc0"]
 sp1 = [
-    "sp1-sdk",
-    "nexus-core/native",
-    "zksync-methods/sp1",
-    "zksync-core/sp1",
-    "adapter_sdk/zkvm-sp1",
+  "sp1-sdk",
+  "nexus-core/native",
+  "zksync-methods/sp1",
+  "zksync-core/sp1",
+  "adapter_sdk/zkvm-sp1",
 ]
 risc0 = [
-    "risc0-zkvm/std",
-    "nexus-core/native",
-    "zksync-methods/risc0",
-    "zksync-core/risc0",
-    "adapter_sdk/zkvm-risc0",
+  "risc0-zkvm/std",
+  "nexus-core/native",
+  "zksync-methods/risc0",
+  "zksync-core/risc0",
+  "adapter_sdk/zkvm-risc0",
 ]

--- a/examples/zksync_adapter/methods/Cargo.toml
+++ b/examples/zksync_adapter/methods/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name              = "zksync-methods"
+name = "zksync-methods"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [build-dependencies]
 risc0-build = { version = "1.0.1", optional = true }
-sp1-build   = { version = "4.1.0", optional = true }
+sp1-build = { version = "4.1.0", optional = true }
 
 [package.metadata.risc0]
-methods = [ "risc0-guest" ]
+methods = ["risc0-guest"]
 
 [features]
 # default = ["risc0"]
-sp1   = [ "sp1-build" ]
-risc0 = [ "risc0-build" ]
+sp1 = ["sp1-build"]
+risc0 = ["risc0-build"]

--- a/examples/zksync_adapter/methods/risc0-guest/Cargo.toml
+++ b/examples/zksync_adapter/methods/risc0-guest/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
-name              = "zksync-adapter"
+name = "zksync-adapter"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 # If you want to try (experimental) std support, add `features = [ "std" ]` to risc0-zkvm
-risc0-zkvm = { version = "2.0.0", default-features = false, features = [
-    "std",
-] }
+risc0-zkvm = { version = "2.0.0", default-features = false, features = ["std"] }
 nexus-core = { path = "../../../../core", default-features = false, features = [
-    "zkvm-risc0",
+  "zkvm-risc0",
 ] }
 zksync-core = { path = "../../core", default-features = false, features = [
-    "zkvm-risc0",
+  "zkvm-risc0",
 ] }

--- a/examples/zksync_adapter/methods/sp1-guest/Cargo.toml
+++ b/examples/zksync_adapter/methods/sp1-guest/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name              = "zksync-adapter-sp1"
+name = "zksync-adapter-sp1"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 # If you want to try (experimental) std support, add `features = [ "std" ]` to risc0-zkvm
 nexus-core = { path = "../../../../core", default-features = false, features = [
-    "zkvm-sp1",
+  "zkvm-sp1",
 ] }
 zksync-core = { path = "../../core", default-features = false, features = [
-    "zkvm-sp1",
+  "zkvm-sp1",
 ] }
-sp1-zkvm = { version = "4.1.0", features = [ "verify" ] }
+sp1-zkvm = { version = "4.1.0", features = ["verify"] }
 sp1-derive = { version = "4.1.0" }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name              = "integration-tests"
+name = "integration-tests"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
-nexus-core   = { path = "../core" }
-tokio        = { version = "1.36.0", features = [ "signal" ] }
-anyhow       = "1.0.89"
-httpmock     = "0.7.0"
-adapter_sdk  = { path = "../adapter_sdk", features = [ "native-risc0" ] }
+nexus-core = { path = "../core" }
+tokio = { version = "1.36.0", features = ["signal"] }
+anyhow = "1.0.89"
+httpmock = "0.7.0"
+adapter_sdk = { path = "../adapter_sdk", features = ["native-risc0"] }
 geth-methods = { path = "../examples/mock_geth_adapter/methods" }
-hex          = "0.4.3"
-avail-rust   = { git = "https://github.com/availproject/avail-rust.git", branch = "toufeeq/scalable-da-2" }
-mock_elf     = { path = "../mock_elf" }
+hex = "0.4.3"
+avail-rust = { git = "https://github.com/availproject/avail-rust.git", branch = "toufeeq/scalable-da-2" }
+mock_elf = { path = "../mock_elf" }

--- a/kzg/Cargo.toml
+++ b/kzg/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name    = "kzg"
+name = "kzg"
 version = "0.1.0"
 edition = "2021"
 
@@ -10,9 +10,9 @@ kate-recovery = { git = "https://github.com/availproject/avail-core.git", branch
 hex = "0.4.3"
 anyhow = "1.0.96"
 bls12_381 = { version = "0.8.0", default-features = false, features = [
-    "groups",
-    "pairings",
-    "alloc",
+  "groups",
+  "pairings",
+  "alloc",
 ] }
-ff = { version = "0.13.0", default-features = false, features = [ "derive" ] }
+ff = { version = "0.13.0", default-features = false, features = ["derive"] }
 ark-ff = { version = "0.4.0-alpha.7", default-features = false }

--- a/mock_elf/Cargo.toml
+++ b/mock_elf/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name              = "mock_elf"
+name = "mock_elf"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [build-dependencies]
 risc0-build = { version = "2.0.0", optional = true }
-sp1-build   = { version = "3.4.0", optional = true }
+sp1-build = { version = "3.4.0", optional = true }
 
 [package.metadata.risc0]
-methods = [ "risc0-guest" ]
+methods = ["risc0-guest"]
 
 [features]
-sp1   = [ "sp1-build" ]
-risc0 = [ "risc0-build" ]
+sp1 = ["sp1-build"]
+risc0 = ["risc0-build"]

--- a/mock_elf/risc0-guest/Cargo.toml
+++ b/mock_elf/risc0-guest/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
-name              = "mock_guest_risc0"
+name = "mock_guest_risc0"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 # If you want to try (experimental) std support, add `features = [ "std" ]` to risc0-zkvm
-risc0-zkvm = { version = "2.0.0", default-features = false, features = [
-    "std",
-] }
-risc0-zkvm-platform = { version = "2.0.0", features = [ "sys-getenv" ] }
+risc0-zkvm = { version = "2.0.0", default-features = false, features = ["std"] }
+risc0-zkvm-platform = { version = "2.0.0", features = ["sys-getenv"] }

--- a/mock_elf/sp1-guest/Cargo.toml
+++ b/mock_elf/sp1-guest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name              = "mock_program_sp1"
+name = "mock_program_sp1"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 
 [dependencies]

--- a/nexus/bench/Cargo.toml
+++ b/nexus/bench/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name              = "bench-nexus"
+name = "bench-nexus"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 nexus-core = { path = "../../core", default-features = false, optional = true }
 prover = { path = "../prover", optional = true }
 sparse-merkle-tree = { git = "https://github.com/vibhurajeev/sparse-merkle-tree.git", rev = "a2f94a7", default-features = false }
 risc0-zkvm = { version = "2.0.0", default-features = false, features = [
-    "std",
+  "std",
 ], optional = true }
 sp1-sdk = { version = "4.1.0", optional = true }
 bincode = "1.3.3"
@@ -18,7 +18,7 @@ nexus-host = { package = "host", path = "../host", default-features = false, opt
 rocksdb = { version = "0.22.0" }
 tokio = "1.36.0"
 serde_json = "1.0.114"
-risc0-zkvm-platform = { version = "2.0.0", features = [ "sys-getenv" ] }
+risc0-zkvm-platform = { version = "2.0.0", features = ["sys-getenv"] }
 serde = "1.0"
 anyhow = "1.0.80"
 
@@ -29,16 +29,11 @@ path = "src/nexus_bench.rs"
 #harness = false                #disable default harness
 
 [features]
-default = [ "risc0" ]
+default = ["risc0"]
 risc0 = [
-    "nexus-core/native-risc0",
-    "risc0-zkvm/metal",
-    "prover/risc0",
-    "nexus-host/risc0",
+  "nexus-core/native-risc0",
+  "risc0-zkvm/metal",
+  "prover/risc0",
+  "nexus-host/risc0",
 ]
-sp1 = [
-    "nexus-core/native-sp1",
-    "sp1-sdk/cuda",
-    "prover/sp1",
-    "nexus-host/sp1",
-]
+sp1 = ["nexus-core/native-sp1", "sp1-sdk/cuda", "prover/sp1", "nexus-host/sp1"]

--- a/nexus/bench/src/nexus_bench.rs
+++ b/nexus/bench/src/nexus_bench.rs
@@ -32,7 +32,7 @@ use env_logger;
 #[cfg(any(feature = "sp1"))]
 use log;
 
-fn create_mock_data(prover_mode: ProverMode) -> (StateMachine<ZKVM, Proof>, Vec<AvailHeader>, HeaderStore) {
+fn create_mock_data(prover_mode: ProverMode) -> (StateMachine<Proof>, Vec<AvailHeader>, HeaderStore) {
     let db_path = "./db";
     let prover_mode_string = match prover_mode {
         ProverMode::NoAggregation => "no_aggregation",
@@ -53,7 +53,7 @@ fn create_mock_data(prover_mode: ProverMode) -> (StateMachine<ZKVM, Proof>, Vec<
     db_options.create_if_missing(true);
 
     let state = Arc::new(Mutex::new(VmState::new(&String::from(runtime_db_path))));
-    let state_machine = StateMachine::<ZKVM, Proof>::new(state.clone());
+    let state_machine = StateMachine::<Proof>::new(state.clone());
 
     let avail_header = File::open("../mock_data/avail_header.json").unwrap();
     let avail_header_reader = BufReader::new(avail_header);

--- a/nexus/host/Cargo.toml
+++ b/nexus/host/Cargo.toml
@@ -1,40 +1,40 @@
 [package]
-name              = "host"
+name = "host"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 avail-rust = { git = "https://github.com/availproject/avail-rust.git", branch = "toufeeq/scalable-da-2" }
 avail-subxt = { git = "https://github.com/availproject/avail.git", tag = "v1.11.0.0", features = [
-    "std",
+  "std",
 ] }
 prover = { path = "../prover", optional = true }
 risc0-zkvm = { version = "2.0.0", default-features = false, optional = true }
 tracing = "0.1.41"
-tracing-subscriber = { version = "0.3", features = [ "env-filter", "time" ] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
 serde = "1.0"
 nexus-core = { path = "../../core", optional = true }
 serde_json = "1.0.114"
-tokio = { version = "1.36.0", features = [ "signal" ] }
+tokio = { version = "1.36.0", features = ["signal"] }
 sp-runtime = "33.0.0"
 relayer = { path = "../../relayer" }
 anyhow = "1.0.89"
 warp = "0.3.6"
 bincode = "1.3.3"
 rocksdb = { version = "0.22.0" }
-jmt = { git = "https://github.com/vibhurajeev/jmt.git", features = [ "mocks" ] }
+jmt = { git = "https://github.com/vibhurajeev/jmt.git", features = ["mocks"] }
 hex = "0.4.3"
 sp1-sdk = { version = "4.1.0", optional = true }
 mockall = "0.13.1"
-reqwest = { version = "0.12.9", features = [ "json" ] }
-utoipa = { version = "5.3", features = [ "axum_extras" ] }
+reqwest = { version = "0.12.9", features = ["json"] }
+utoipa = { version = "5.3", features = ["axum_extras"] }
 utoipa-swagger-ui = "5.0"
 kzg = { path = "../../kzg" }
 
 [features]
-default = [ "risc0" ]                                                     # need to change this to run with sp1
-sp1     = [ "sp1-sdk", "nexus-core/native-sp1", "prover/sp1" ]
-risc0   = [ "risc0-zkvm/std", "nexus-core/native-risc0", "prover/risc0" ]
+default = ["risc0"]                                                   # need to change this to run with sp1
+sp1 = ["sp1-sdk", "nexus-core/native-sp1", "prover/sp1"]
+risc0 = ["risc0-zkvm/std", "nexus-core/native-risc0", "prover/risc0"]
 
 [patch.crates-io]
 serde = { version = "1.0.204" }

--- a/nexus/host/src/lib.rs
+++ b/nexus/host/src/lib.rs
@@ -253,6 +253,14 @@ pub async fn prover_handle(
                 )
                 .await?;
 
+            shared_db
+                .insert_proof(
+                    block_to_prove as u64,
+                    block_with_info.block.header.hash(),
+                    bincode::serialize(&proof_result.unwrap().0)?,
+                )
+                .await?;
+
             block_to_prove += 1;
         }
     }

--- a/nexus/host/src/rpc.rs
+++ b/nexus/host/src/rpc.rs
@@ -5,8 +5,8 @@ use nexus_core::mempool::Mempool;
 use nexus_core::state::VmState;
 use nexus_core::state_machine::StateMachine;
 use nexus_core::types::{
-    AccountState, AccountWithProof, AvailHeader, HeaderStore, NexusBlockWithPointers, NexusBlockWithTransactions, NexusHeader, StatementDigest,
-    Transaction, TransactionWithStatus, H256,
+    AccountState, AccountWithProof, AvailHeader, BlockProof, HeaderStore, NexusBlockWithPointers, NexusBlockWithTransactions, NexusHeader,
+    StatementDigest, Transaction, TransactionWithStatus, H256,
 };
 use nexus_core::utils::hasher::Sha256;
 use serde::{Deserialize, Serialize};
@@ -91,6 +91,7 @@ impl From<AccountWithProof> for AccountWithProofHex {
         submit_tx,
         tx_status,
         get_block,
+        get_block_proof,
         get_state,
         get_state_hex,
         get_header,
@@ -107,6 +108,7 @@ impl From<AccountWithProof> for AccountWithProofHex {
             nexus_core::types::InitAccount,
             nexus_core::types::NexusHeader,
             nexus_core::types::TransactionStatus,
+            nexus_core::types::BlockProof,
             nexus_core::state::types::AccountState,
             nexus_core::state::types::StatementDigest
         )
@@ -149,6 +151,86 @@ async fn submit_tx(mempool: Mempool, tx: Transaction) -> Result<WithStatus<Strin
         )),
         Err(_) => Ok(warp::reply::with_status(
             "Internal Mempool error".to_string(),
+            warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+        )),
+    }
+}
+
+/// Get block proof by hash, number or latest
+#[utoipa::path(
+    get,
+    path = "/block-proof",
+    tag = "nexus",
+    params(
+        ("block_hash" = Option<String>, Query, description = "Block hash in hex format. If not provided, returns the latest block"),
+        ("block_number" = Option<u32>, Query, description = "Block number to query. If not provided, returns the latest block")
+    ),
+    responses(
+        (status = 200, description = "Block found", body = BlockProof),
+        (status = 404, description = "Block not found", body = String),
+        (status = 400, description = "Invalid hash format", body = String),
+        (status = 500, description = "Internal error", body = String)
+    )
+)]
+async fn get_block_proof(
+    db: Arc<Mutex<NodeDB>>,
+    shared_db: Arc<SharedDB>,
+    block_hash_opt: Option<H256>,
+    block_number_opt: Option<u32>,
+) -> Result<WithStatus<String>, Rejection> {
+    let db_lock = db.lock().await;
+
+    let nexus_block_number = if block_number_opt.is_some() {
+        block_number_opt.unwrap()
+    } else {
+        match block_hash_opt {
+            Some(hash) => match db_lock.get::<NexusBlockWithPointers>(&[hash.as_slice(), b"-block"].concat()) {
+                Ok(Some(block)) => block.block.header.number,
+                Ok(None) => {
+                    return Ok(warp::reply::with_status(
+                        "Nexus height does not exist".to_string(),
+                        warp::http::StatusCode::BAD_REQUEST,
+                    ))
+                }
+                Err(e) => {
+                    return Ok(warp::reply::with_status(
+                        "Internal error when retrieving block to nexus hash mapping".to_string(),
+                        warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    ))
+                }
+            },
+            None => {
+                return Ok(warp::reply::with_status(
+                    "Internal error when retrieving block to nexus hash mapping".to_string(),
+                    warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+                ))
+            }
+        }
+    };
+
+    let block_proof = match shared_db.get_block_proof_by_number(nexus_block_number as u64).await {
+        Ok(Some(b)) => b,
+        Ok(None) => {
+            return Ok(warp::reply::with_status(
+                "Block not found".to_string(),
+                warp::http::StatusCode::BAD_REQUEST,
+            ))
+        }
+        Err(_) => {
+            return Ok(warp::reply::with_status(
+                "Error retrieving block".to_string(),
+                warp::http::StatusCode::INTERNAL_SERVER_ERROR,
+            ))
+        }
+    };
+
+    match serde_json::to_string(&block_proof) {
+        Ok(serialized_response) => Ok(warp::reply::with_status(
+            serialized_response,
+            warp::http::StatusCode::OK,
+        )),
+        Err(_) => Ok(warp::reply::with_status(
+            "Internal encoding error".to_string(),
             warp::http::StatusCode::INTERNAL_SERVER_ERROR,
         )),
     }
@@ -636,6 +718,8 @@ pub fn routes(
     let db_clone_3 = db.clone();
     let db_clone_4 = db.clone();
     let db_clone_5 = db.clone();
+    let db_clone_6 = db.clone();
+    let shared_db_1 = shared_db.clone();
 
     let health_check = warp::path("health")
         .and(warp::get())
@@ -707,6 +791,45 @@ pub fn routes(
                 };
 
                 get_block(db, shared_db, block_hash, block_number).await
+            },
+        );
+
+    let block_proof = warp::path("block-proof")
+        .and(warp::get())
+        .and(warp::any().map(move || db_clone_6.clone()))
+        .and(warp::any().map(move || shared_db_1.clone()))
+        .and(warp::query::<HashMap<String, String>>())
+        .and_then(
+            |db: Arc<Mutex<NodeDB>>, shared_db: Arc<SharedDB>, params: HashMap<String, String>| async move {
+                let block_hash = match params
+                    .get("block_hash")
+                    .map(|hash_str| H256::try_from(hash_str.as_str()))
+                    .transpose()
+                    .map_err(|_| {
+                        warp::reply::with_status(
+                            "Invalid hash".to_string(),
+                            warp::http::StatusCode::BAD_REQUEST,
+                        )
+                    }) {
+                    Ok(i) => i,
+                    Err(e) => return Ok(e),
+                };
+
+                let block_number = match params
+                    .get("block_number")
+                    .map(|hash_str| hash_str.parse::<u32>())
+                    .transpose()
+                    .map_err(|_| {
+                        warp::reply::with_status(
+                            "Invalid block number".to_string(),
+                            warp::http::StatusCode::BAD_REQUEST,
+                        )
+                    }) {
+                    Ok(i) => i,
+                    Err(e) => return Ok(e),
+                };
+
+                get_block_proof(db, shared_db, block_hash, block_number).await
             },
         );
 
@@ -817,6 +940,7 @@ pub fn routes(
     tx.or(health_check)
         .or(tx_status)
         .or(block)
+        .or(block_proof)
         .or(submit_batch)
         .or(header)
         .or(account)

--- a/nexus/prover/Cargo.toml
+++ b/nexus/prover/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name              = "prover"
+name = "prover"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [build-dependencies]
 risc0-build = { version = "2.0.0", optional = true }
-sp1-build   = { version = "4.1.0", optional = true }
+sp1-build = { version = "4.1.0", optional = true }
 
 [package.metadata.risc0]
-methods = [ "risc0-guest" ]
+methods = ["risc0-guest"]
 
 [features]
-sp1   = [ "sp1-build" ]
-risc0 = [ "risc0-build" ]
+sp1 = ["sp1-build"]
+risc0 = ["risc0-build"]

--- a/nexus/prover/risc0-guest/Cargo.toml
+++ b/nexus/prover/risc0-guest/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
-name              = "nexus_runtime"
+name = "nexus_runtime"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 # If you want to try (experimental) std support, add `features = [ "std" ]` to risc0-zkvm
-risc0-zkvm = { version = "2.0.0", default-features = false, features = [
-    "std",
-] }
+risc0-zkvm = { version = "2.0.0", default-features = false, features = ["std"] }
 nexus-core = { path = "../../../core", default-features = false, features = [
-    "zkvm-risc0",
+  "zkvm-risc0",
 ] }
-risc0-zkvm-platform = { version = "2.0.0", features = [ "sys-getenv" ] }
+risc0-zkvm-platform = { version = "2.0.0", features = ["sys-getenv"] }

--- a/nexus/prover/sp1-guest/Cargo.toml
+++ b/nexus/prover/sp1-guest/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name              = "nexus_runtime_sp1"
+name = "nexus_runtime_sp1"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 
 [dependencies]
 # If you want to try (experimental) std support, add `features = [ "std" ]` to risc0-zkvm
 risc0-zkvm = { version = "2.0.0", default-features = false, features = [
-    "std",
+  "std",
 ], optional = true }
 nexus-core = { path = "../../../core", default-features = false, features = [
-    "zkvm-sp1",
+  "zkvm-sp1",
 ] }
-sp1-zkvm = { version = "4.1.0", features = [ "verify" ] }
+sp1-zkvm = { version = "4.1.0", features = ["verify"] }

--- a/nexus_bench_setup/Cargo.toml
+++ b/nexus_bench_setup/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
-name              = "nexus_bench_setup"
+name = "nexus_bench_setup"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
 avail-core = { git = "https://github.com/availproject/avail-core.git", branch = "toufeeq/scalable-da-2", features = [
-    "runtime",
+  "runtime",
 ] }
 kate = { git = "https://github.com/availproject/avail-core.git", branch = "toufeeq/scalable-da-2" }
 geth-methods = { path = "../examples/mock_geth_adapter/methods" }
 nexus-host = { package = "host", path = "../nexus/host", default-features = false, optional = true }
 prover = { path = "../nexus/prover", optional = true }
-risc0-zkvm = { version = "2.0.0", features = [ "default", "metal", "prove" ] }
-tracing-subscriber = { version = "0.3", features = [ "env-filter" ] }
+risc0-zkvm = { version = "2.0.0", features = ["default", "metal", "prove"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rocksdb = { version = "0.22.0" }
 serde = "1.0"
-nexus-core = { path = "../core", features = [ "native-risc0" ] }
+nexus-core = { path = "../core", features = ["native-risc0"] }
 serde_json = "1.0.114"
 tokio = "1.36.0"
 sp-runtime = "33.0.0"
 parity-scale-codec = { version = "3", default-features = false, features = [
-    "derive",
-    "max-encoded-len",
+  "derive",
+  "max-encoded-len",
 ] }
 relayer = { path = "../relayer" }
-adapter_sdk = { path = "../adapter_sdk", features = [ "native-risc0" ] }
+adapter_sdk = { path = "../adapter_sdk", features = ["native-risc0"] }
 geth-adapter-core = { path = "../examples/mock_geth_adapter/core" }
 anyhow = "1.0.80"
 actix-web = "4.5.1"
@@ -36,6 +36,6 @@ mock_elf = { path = "../mock_elf" }
 rand = "0.9.0"
 
 [features]
-default = [ "risc0" ]
-risc0   = [ "nexus-core/native-risc0", "prover/risc0", "nexus-host/risc0" ]
-sp1     = [ "nexus-core/native-sp1", "prover/sp1", "nexus-host/sp1" ]
+default = ["risc0"]
+risc0 = ["nexus-core/native-risc0", "prover/risc0", "nexus-host/risc0"]
+sp1 = ["nexus-core/native-sp1", "prover/sp1", "nexus-host/sp1"]

--- a/nexus_bench_setup/src/main.rs
+++ b/nexus_bench_setup/src/main.rs
@@ -49,7 +49,7 @@ struct AdapterStateData {
     adapter_config: AdapterConfig,
 }
 
-fn create_mock_data(prover_mode: ProverMode) -> (StateMachine<ZKVM, Proof>, HeaderStore) {
+fn create_mock_data(prover_mode: ProverMode) -> (StateMachine<Proof>, HeaderStore) {
     let db_path = "./db";
 
     let runtime_db_path = String::from("./db/runtime_db");
@@ -62,7 +62,7 @@ fn create_mock_data(prover_mode: ProverMode) -> (StateMachine<ZKVM, Proof>, Head
     db_options.create_if_missing(true);
 
     let state = Arc::new(Mutex::new(VmState::new(&String::from(runtime_db_path))));
-    let state_machine = StateMachine::<ZKVM, Proof>::new(state.clone());
+    let state_machine = StateMachine::<Proof>::new(state.clone());
 
     let header_store: HeaderStore = HeaderStore::new(23);
 

--- a/nexus_cli/Cargo.toml
+++ b/nexus_cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name              = "nexus_cli"
+name = "nexus_cli"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 [dependencies]
-clap = { version = "4.5.16", features = [ "derive" ] }
+clap = { version = "4.5.16", features = ["derive"] }

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name              = "relayer"
+name = "relayer"
 version.workspace = true
-edition           = "2021"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio        = "1.36.0"
+tokio = "1.36.0"
 tokio-stream = "0.1.14"
-avail-rust   = { git = "https://github.com/availproject/avail-rust.git", branch = "toufeeq/scalable-da-2" }
-serde        = "1.0.196"
-serde_json   = "1.0.113"
-nexus-core   = { path = "../core" }
+avail-rust = { git = "https://github.com/availproject/avail-rust.git", branch = "toufeeq/scalable-da-2" }
+serde = "1.0.196"
+serde_json = "1.0.113"
+nexus-core = { path = "../core" }
 
 [patch.crates-io]
-sp-core         = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
-sp-io           = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
-sp-runtime      = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
-sp-std          = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
+sp-core = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
+sp-io = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
+sp-runtime = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
+sp-std = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }
 sp-core-hashing = { git = "https://github.com/availproject/substrate.git", branch = "goldberg" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "1.85"
-components = [ "rustfmt", "rust-src" ]
-profile    = "minimal"
+channel = "1.85"
+components = ["rustfmt", "rust-src"]
+profile = "minimal"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
-max_width        = 150
-fn_call_width    = 60
+max_width = 150
+fn_call_width = 60
 struct_lit_width = 40

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,9 +1,9 @@
 [formatting]
-array_trailing_comma  = true
-column_width          = 80
-compact_arrays        = false
+array_trailing_comma = true
+column_width = 80
+compact_arrays = false
 compact_inline_tables = false
-indent_string         = "    "
-reorder_keys          = false
-reorder_arrays        = false
-align_entries         = true
+indent_string = "    "
+reorder_keys = false
+reorder_arrays = false
+align_entries = true


### PR DESCRIPTION
- Added proof storage in prover execution and added a route `/block-proof` in rpc crate. 
- One can query block proof using `block number` or `block hash`.
- Fixed bench crate build.